### PR TITLE
[INSIGHTS-6909] Pin setuptools  to 73.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools",
+    # pinning setuptools https://instabase.slack.com/archives/CCY413CSU/p1724808224251339?thread_ts=1724790820.987119&cid=CCY413CSU
+    "setuptools==73.0.1",
     "wheel",
     "Cython>=0.28.5, <3.0.0",
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX' and platform_python_implementation == 'CPython'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,10 @@ requires = [
     "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX' and platform_python_implementation == 'CPython'",
     "numpy==1.14.0; python_version=='3.6' and platform_system!='AIX' and platform_python_implementation != 'CPython'",
     "numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'",
+    "numpy==1.17.3; python_version=='3.8' and platform_system!='AIX'",
     "numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'",
     "numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'",
-    "numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'",
+    "numpy==1.17.3; python_version=='3.8' and platform_system=='AIX'",
+    "numpy==1.22.3; python_version!='3.10' or platform_system!='Windows' or platform_python_implementation=='PyPy'",
     "scipy>=0.19.1",
 ]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Pins setuptools as done [here](https://github.com/instabase/scikit-learn/commit/780c8e8753b9b93562e0d739f35697a68baed54f) on the main branch but for 0.23.2-ib, which is used in 24.01, 23.10, 23.07. 




#### What does this implement/fix? Explain your changes.
This fixes the original issue with setuptools discussed in [#_inc-522-setuptools-breaking-releases](https://join.slack.com/share/enQtNzY3MDkwMjI1NjE5NS0zNGM2NDE4NjZjNzJjYzZhOTZkZWQ4N2UzNTYwOTk2ZTQwZDc5OWU4ZWE1Y2ViODcxN2JhOWYwZjdhMThiN2My) 

#### Any other comments?
- when this is merged, we need to update the release branches for 24.01, 23.10, 23.07 to point back at this branch of scikitlearn

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
